### PR TITLE
Multiple changes: Add test support for Reuters articles. Test articles endpoint. Custom headings for requests

### DIFF
--- a/configs/data.sql
+++ b/configs/data.sql
@@ -3,5 +3,7 @@ USE rss_articles_db;
 -- Inserting default rows in the rss feeds 
 INSERT IGNORE INTO rss_feed (url, name) VALUES
     ('https://foreignpolicy.com/feed/', 'foreign_policy_magazine'),
-    ('https://www.38north.org/rss', '38_north');
+    ('https://www.38north.org/rss', '38_north'),
+    ('https://www.reutersagency.com/feed/?best-regions=asia&post_type=best', "reuters_asia"),
+    ('https://www.reutersagency.com/feed/?best-topics=political-general&post_type=best', 'reuters_politics');
 

--- a/src/article_scheduler/app/local_db_config.py
+++ b/src/article_scheduler/app/local_db_config.py
@@ -13,7 +13,19 @@ rss_feeds = [
         "url": "https://www.38north.org/feed/",
         "etag": None,
         "last_updated_date": None
-    }
+    },
+    {
+        "pk":3,
+        "url":"https://www.reutersagency.com/feed/?best-regions=asia&post_type=best",
+        "etag": None,
+        "last_updated_date": None
+    },
+    {
+        "pk":4,
+        "url":"https://www.reutersagency.com/feed/?best-topics=political-general&post_type=best",
+        "etag": None,
+        "last_updated_date": None
+    },
 
 ]
 

--- a/src/article_scheduler/app/main.py
+++ b/src/article_scheduler/app/main.py
@@ -217,6 +217,9 @@ async def manually_trigger_feed_ingestion():
     # All RSS Feeds that need to be parsed manually need to be added here:
     scheduler.get_job(job_id="https://www.38north.org/feed/").modify(next_run_time=datetime.datetime.now())
     scheduler.get_job(job_id="https://foreignpolicy.com/feed/").modify(next_run_time=datetime.datetime.now())
+    scheduler.get_job(job_id="https://www.reutersagency.com/feed/?best-regions=asia&post_type=best").modify(next_run_time=datetime.datetime.now())
+    scheduler.get_job(job_id="https://www.reutersagency.com/feed/?best-topics=political-general&post_type=best").modify(next_run_time=datetime.datetime.now())
+
 
     logger.info("Manually triggering bulk rss feed function")
  

--- a/src/static_file_ingestor/static_file_ingestor_python/process_article_objects.py
+++ b/src/static_file_ingestor/static_file_ingestor_python/process_article_objects.py
@@ -1,11 +1,21 @@
 import requests
 import minio
 import time
+import random
 import io 
 from datetime import datetime
 from typing import Literal
 
 from static_file_ingestor_logger import logger
+    
+user_agents = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Firefox/65.0.1",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Edge/16.16299",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:85.0) Gecko/20100101 Firefox/85.0",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.192 Safari/537.36",
+]
+
 
 def upload_article_html_to_bucket(
     minio_endpoint: str,
@@ -60,9 +70,20 @@ def upload_article_html_to_bucket(
     new_article_object_name: str = f"{DATE_POSTED}/{file_title}.html"
 
     try:
+
         # 4) Make request to url from article content to extract html file
         time.sleep(0.5)
-        article_response: requests.Response = requests.get(article['url'])
+
+        random_user_agent: str = random.choice(user_agents)
+        request_headers: dict[str, str] = {
+            "User-Agent": random_user_agent
+        }
+
+        article_response: requests.Response = requests.get(
+            url=article['url'],
+            headers=request_headers
+        )
+
         article_response.raise_for_status()
 
     except requests.exceptions.HTTPError as e:

--- a/src/static_file_ingestor/static_file_ingestor_python/static_file_ingestor.py
+++ b/src/static_file_ingestor/static_file_ingestor_python/static_file_ingestor.py
@@ -8,17 +8,17 @@ import uvicorn
 import threading
 import fastapi
 import datetime
+import requests
 from fastapi.middleware.cors import CORSMiddleware
 import pandas as pd 
-import uuid
-import time
+import random
 import json
 
 import pika
 from pika.adapters.blocking_connection import BlockingChannel
 
 from static_file_ingestor_logger import logger
-from process_article_objects import upload_article_html_to_bucket 
+from process_article_objects import upload_article_html_to_bucket, user_agents 
 
 MINIO_ENDPOINT: str = os.environ.get("MINIO_ENDPOINT", "localhost")
 MINIO_ACCESS_KEY: str = os.environ.get("MINIO_ACCESS_KEY", "admin")
@@ -99,6 +99,7 @@ async def perform_database_static_file_ingestion(max_articles: int | None = None
             WHERE in_storage_bucket = false; 
             """)
         with engine.connect() as conn, conn.begin():
+
             articles_not_in_bucket_df = pd.read_sql_query(get_articles_not_in_bucket_query, con=conn)
 
 
@@ -182,6 +183,34 @@ async def perform_database_static_file_ingestion(max_articles: int | None = None
     }
 
     return ingested_info 
+
+@app.get("/test_request_logic")
+async def test_rss_feed_article_ingestion(url: str):
+    "Function allows a user to make a http request to the provided url in order to debug request issues"
+    test_response_content = {"url_provided_for_testing": url}
+    
+    random_user_agent: str = random.choice(user_agents)
+    request_headers: dict[str, str] = {
+        "User-Agent": random_user_agent
+    }
+    
+    test_response_content['input_headers'] = request_headers
+
+    response = requests.get(url, headers=request_headers)
+
+    try:
+        response.raise_for_status()
+        test_response_content['status_code'] = response.status_code
+        test_response_content['content'] = response.content
+        test_response_content['response_headers'] = response.headers
+    
+    except Exception as e:
+        test_response_content['status_code'] = response.status_code
+        test_response_content['content'] = response.content
+        test_response_content['response_headers'] = response.headers
+        test_response_content['request_error'] = str(e)
+
+    return test_response_content
 
 
 def consume_message():

--- a/src/static_file_ingestor/static_file_ingestor_python/static_file_ingestor.py
+++ b/src/static_file_ingestor/static_file_ingestor_python/static_file_ingestor.py
@@ -244,6 +244,9 @@ def consume_message():
                 """)
 
                 updated_article = session.execute(update_query, {"title":article['title']})
+                session.commit()
+                session.close()
+
                 rows_inserted = updated_article.rowcount
 
                 if rows_inserted == 1:
@@ -257,8 +260,6 @@ def consume_message():
                         "rss_feed": article['rss_feed_id']
                     })
 
-                session.commit()
-                session.close()
 
         if upload_status == 200:
            channel.basic_ack(delivery_tag=method.delivery_tag)


### PR DESCRIPTION
Three main changes this PR:

1) Added support for urls for reuters asia and politics.

2) This highlighted some issues around making requests to ingest these articles. I kept getting 403 responses for the Reuters which was because I had no request headers. A added a small snippet to the request portion of the storage bucket ingestor that rotates through a list of request headers. This fixed the issues with making requests and it fixed the issues for 38North and Reuters 403s.

3) The 403 forbidden errors prompted me to add an endpoint to the storage bucket ingestor service that allows me to pass a url into the main python requests function and returns the status of the requests and any other debugging information.    