### PR TITLE
Added rss url caching to reduce main database query load for snowflake. Added additional rss feeds. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ cover/
 *.log
 *.log*
 local_settings.py
-db.sqlite3
+*db.sqlite3
 db.sqlite3-journal
 
 # Flask stuff:

--- a/configs/data.sql
+++ b/configs/data.sql
@@ -5,5 +5,12 @@ INSERT IGNORE INTO rss_feed (url, name) VALUES
     ('https://foreignpolicy.com/feed/', 'foreign_policy_magazine'),
     ('https://www.38north.org/rss', '38_north'),
     ('https://www.reutersagency.com/feed/?best-regions=asia&post_type=best', "reuters_asia"),
-    ('https://www.reutersagency.com/feed/?best-topics=political-general&post_type=best', 'reuters_politics');
+    ('https://www.reutersagency.com/feed/?best-topics=political-general&post_type=best', 'reuters_politics'),
+    ('https://spacenews.com/feed/', 'space_news'),
+    ('https://www.defensenews.com/arc/outboundfeeds/rss/category/space/?outputType=xml', 'defense_news_space'),
+    ('https://www.defensenews.com/arc/outboundfeeds/rss/category/air/?outputType=xml', 'defense_news_air'),
+    ('https://www.defensenews.com/arc/outboundfeeds/rss/category/training-sim/?outputType=xml', 'defense_news_training_sim'),
+    ('https://www.defensenews.com/arc/outboundfeeds/rss/category/global/?outputType=xml', 'defense_news_global'),
+    ('https://www.defensenews.com/arc/outboundfeeds/rss/category/industry/?outputType=xml', 'defense_news_industry'),
+    ('https://www.defensenews.com/arc/outboundfeeds/rss/category/naval/?outputType=xml', 'defense_news_naval');
 

--- a/src/article_scheduler/app/local_db_config.py
+++ b/src/article_scheduler/app/local_db_config.py
@@ -26,6 +26,48 @@ rss_feeds = [
         "etag": None,
         "last_updated_date": None
     },
+    {
+        "pk":5,
+        "url":"https://spacenews.com/feed/",
+        "etag": None,
+        "last_updated_date":None
+    },
+    {
+        "pk":6,
+        "url":"https://www.defensenews.com/arc/outboundfeeds/rss/category/space/?outputType=xml",
+        "etag": None,
+        "last_updated_date":None
+    },
+    {
+        "pk":7,
+        "url":"https://www.defensenews.com/arc/outboundfeeds/rss/category/air/?outputType=xml",
+        "etag": None,
+        "last_updated_date":None
+    },
+    {
+        "pk":8,
+        "url":"https://www.defensenews.com/arc/outboundfeeds/rss/category/training-sim/?outputType=xml",
+        "etag": None,
+        "last_updated_date":None
+    },
+    {
+        "pk":9,
+        "url":"https://www.defensenews.com/arc/outboundfeeds/rss/category/global/?outputType=xml",
+        "etag": None,
+        "last_updated_date":None
+    },
+    {
+        "pk":10,
+        "url":"https://www.defensenews.com/arc/outboundfeeds/rss/category/industry/?outputType=xml",
+        "etag": None,
+        "last_updated_date":None
+    },
+    {
+        "pk":11,
+        "url":"https://www.defensenews.com/arc/outboundfeeds/rss/category/naval/?outputType=xml",
+        "etag": None,
+        "last_updated_date":None
+    },
 
 ]
 

--- a/src/article_scheduler/app/main.py
+++ b/src/article_scheduler/app/main.py
@@ -216,10 +216,20 @@ async def manually_trigger_feed_ingestion():
 
     # All RSS Feeds that need to be parsed manually need to be added here:
     scheduler.get_job(job_id="https://www.38north.org/feed/").modify(next_run_time=datetime.datetime.now())
+
     scheduler.get_job(job_id="https://foreignpolicy.com/feed/").modify(next_run_time=datetime.datetime.now())
+    
     scheduler.get_job(job_id="https://www.reutersagency.com/feed/?best-regions=asia&post_type=best").modify(next_run_time=datetime.datetime.now())
     scheduler.get_job(job_id="https://www.reutersagency.com/feed/?best-topics=political-general&post_type=best").modify(next_run_time=datetime.datetime.now())
 
+    scheduler.get_job(job_id="https://spacenews.com/feed/").modify(next_run_time=datetime.datetime.now())
+    
+    scheduler.get_job(job_id="https://www.defensenews.com/arc/outboundfeeds/rss/category/space/?outputType=xml").modify(next_run_time=datetime.datetime.now())
+    scheduler.get_job(job_id="https://www.defensenews.com/arc/outboundfeeds/rss/category/air/?outputType=xml").modify(next_run_time=datetime.datetime.now())
+    scheduler.get_job(job_id="https://www.defensenews.com/arc/outboundfeeds/rss/category/training-sim/?outputType=xml").modify(next_run_time=datetime.datetime.now())
+    scheduler.get_job(job_id="https://www.defensenews.com/arc/outboundfeeds/rss/category/global/?outputType=xml").modify(next_run_time=datetime.datetime.now())
+    scheduler.get_job(job_id="https://www.defensenews.com/arc/outboundfeeds/rss/category/industry/?outputType=xml").modify(next_run_time=datetime.datetime.now())
+    scheduler.get_job(job_id="https://www.defensenews.com/arc/outboundfeeds/rss/category/naval/?outputType=xml").modify(next_run_time=datetime.datetime.now())
 
     logger.info("Manually triggering bulk rss feed function")
  

--- a/src/article_scheduler/app/scheduler_config.py
+++ b/src/article_scheduler/app/scheduler_config.py
@@ -14,8 +14,6 @@ jobstores = {
 scheduler = BackgroundScheduler(jobstores=jobstores)
 scheduler.start()
 
-# Foreign Policy Article Feed emitter runs every day:
-
 with local_sqlite_engine.connect() as conn, conn.begin():
     results = conn.execute(sa.text("SELECT * FROM rss_feeds"))
     rows = results.fetchall()

--- a/src/snowflake/requirements.txt
+++ b/src/snowflake/requirements.txt
@@ -19,3 +19,4 @@ pika==1.3.2
 python-logging-rabbitmq==2.2.0
 fastapi==0.96.0
 uvicorn==0.22.0
+APScheduler==3.10.2

--- a/src/snowflake/snowflake_python/existing_article_caching.py
+++ b/src/snowflake/snowflake_python/existing_article_caching.py
@@ -1,0 +1,113 @@
+import os
+import pathlib
+
+from sqlalchemy.engine.url import URL
+from sqlalchemy.orm import sessionmaker
+import sqlalchemy as sa
+import sqlite3
+
+from broker_logger import logger
+
+def rebuild_article_cache(path_url: str):
+    "Fully rebuilds the sqlite article cache based on the local filepath"
+    logger.info("Triggering article cache rebuild")
+    
+    cache_db_path: pathlib.Path = pathlib.Path(path_url)
+
+    engine_url = URL.create(
+        drivername="mysql+mysqldb",
+        username=os.environ.get("USERNAME"),
+        password=os.environ.get("PASSWORD"),
+        host=os.environ.get("HOST"),
+        database=os.environ.get("DATABASE")
+    )   
+
+    engine = sa.create_engine(engine_url, connect_args={"ssl":{"ca":"/etc/ssl/certs/ca-certificates.crt"}})
+    MainDBSession = sessionmaker(bind=engine)
+
+    print("Triggering Article Cache rebuild")
+
+    if cache_db_path.is_file():
+        cache_db_path.unlink()
+        logger.info("Deleted current existing Cache")
+
+    
+    sqlite_conn = sqlite3.connect(cache_db_path)
+    sqlite_cursor = sqlite_conn.cursor()
+    
+    sqlite_cursor.execute("""       
+        CREATE TABLE IF NOT EXISTS local_articles (
+            url TEXT PRIMARY KEY
+        )"""
+    )
+    sqlite_conn.commit()
+    logger.info("Created logging cache table")
+    
+    with MainDBSession() as session:
+        articles: tuple = session.execute(sa.text("SELECT url FROM article")).fetchall()
+        logger.info("Queried all existing urls from the main database", extra={"number_articles": len(articles)})
+
+    sqlite_cursor.executemany(
+            'INSERT OR IGNORE INTO local_articles (url) VALUES (?)',
+            articles
+        )
+    
+    sqlite_conn.commit()
+    logger.info("Adding all articles from the main database to the local cache", extra={"number_articles": len(articles)})
+    sqlite_conn.close()
+
+def determine_article_in_db(url: str) -> bool:
+    "Wraps all of the logic for determining if an article exists in the database"
+    engine_url = URL.create(
+        drivername="mysql+mysqldb",
+        username=os.environ.get("USERNAME"),
+        password=os.environ.get("PASSWORD"),
+        host=os.environ.get("HOST"),
+        database=os.environ.get("DATABASE")
+    )
+
+    engine = sa.create_engine(engine_url, connect_args={"ssl":{"ca":"/etc/ssl/certs/ca-certificates.crt"}})
+
+    MainDBSession = sessionmaker(bind=engine)
+
+    # First we check to see if the article db cache exists:
+    sqlite_cache_path_str: str = "article_cache.db.sqlite3"
+    sqlite_cache_path: pathlib.Path = pathlib.Path(sqlite_cache_path_str)
+
+    if not sqlite_cache_path.is_file():
+        logger.info("Existing article cache not found. Rebuilding cache from main database")
+        rebuild_article_cache(path_url=sqlite_cache_path_str)
+       
+    # Check to see if the url exists in the cached article db:
+    with sqlite3.connect(sqlite_cache_path) as sqlite_conn:
+        sqlite_cursor = sqlite_conn.cursor()
+        existing_article = sqlite_cursor.execute("SELECT url FROM local_articles WHERE url= :url", {"url":url}).fetchone()
+        
+        # Url in cache, already exists:
+        if existing_article is not None:
+            logger.debug("Provided url exists in the cache", extra={"url": url})
+            return True
+        
+        # Article still might exist in the main db:
+        else:
+            logger.info("url was not found in the cache, checking the main database for article", extra={"url":url})
+            with MainDBSession() as session:
+
+                article_unique_query = sa.text("SELECT id FROM article WHERE url = :url")
+                existing_article = session.execute(article_unique_query, {"url":url}).fetchone()
+
+                # Article does exist in the main db:
+            if existing_article is not None:
+                logger.info("url was found in the main database not in cache", extra={'url':url})
+                return True
+            
+            # Article not in the cache or the main db. It is unique:
+            else:
+                logger.info("url was not found in the cache or the main database. article is unique.", extra={'url':url})
+                return False
+
+    
+
+
+
+


### PR DESCRIPTION
Added new rss feeds for space, aviation, defense. 

Added caching logic for the snowflake service. Every 6 hours a cache is created with all of the urls from the main db. It is used to check for already existing articles instead of hitting the main db. If the article isn't in the cache then it checks the main db with a query. This should reduce the number of individual queries to the database for snowflake, which has been the heaviest service on the db.