### PR TITLE
Pika connection error catching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,27 @@ parser_env/
 data/
 
 *grafana
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+*/article_ner_service
+*/article_frontend
+
+.DS_Store

--- a/src/article_ingestor/article_ingestor_python/article_ingestor.py
+++ b/src/article_ingestor/article_ingestor_python/article_ingestor.py
@@ -107,7 +107,13 @@ def consume_messages():
         session.close()
 
     try:
-        connection = pika.BlockingConnection(pika.ConnectionParameters(host=os.environ.get("BROKER_URL", "localhost")))
+        connection = pika.BlockingConnection(
+            pika.ConnectionParameters(
+                host=os.environ.get("BROKER_URL", "localhost"),
+                heartbeat=600,
+                blocked_connection_timeout=300
+            )
+        )
 
         channel = connection.channel()
 

--- a/src/article_scheduler/app/main.py
+++ b/src/article_scheduler/app/main.py
@@ -128,7 +128,11 @@ async def emit_mock_rss_data():
     ]
 
     connection = pika.BlockingConnection(
-        pika.ConnectionParameters(os.environ.get("BROKER_URL", "localhost"))
+        pika.ConnectionParameters(
+            os.environ.get("BROKER_URL", "localhost"),
+            heartbeat=600,
+            blocked_connection_timeout=300
+        )
     )
     channel = connection.channel()
 

--- a/src/logger/logger_python/logger.py
+++ b/src/logger/logger_python/logger.py
@@ -32,7 +32,12 @@ logger.addHandler(file_handler)
 
 def main():
     connection = pika.BlockingConnection(
-        pika.ConnectionParameters(host=os.environ.get("BROKER_URL", "localhost")))
+        pika.ConnectionParameters(
+            host=os.environ.get("BROKER_URL", "localhost"),
+            heartbeat=600,
+            blocked_connection_timeout=300
+        )
+    )
 
     channel = connection.channel()
     

--- a/src/snowflake/snowflake_python/existing_article_caching.py
+++ b/src/snowflake/snowflake_python/existing_article_caching.py
@@ -47,6 +47,9 @@ def rebuild_article_cache(path_url: str):
         articles: tuple = session.execute(sa.text("SELECT url FROM article")).fetchall()
         logger.info("Queried all existing urls from the main database", extra={"number_articles": len(articles)})
 
+        # Manually adding the test google url to the cache for processing test urls:
+        articles.append(('https://www.google.com/', ))
+
     sqlite_cursor.executemany(
             'INSERT OR IGNORE INTO local_articles (url) VALUES (?)',
             articles

--- a/src/snowflake/snowflake_python/snowflake.py
+++ b/src/snowflake/snowflake_python/snowflake.py
@@ -66,7 +66,7 @@ def consume_messages():
             # Manually testing the article cache check:
             try:
                 test_article_in_db: bool = determine_article_in_db(article['url'])
-                logger.debug("Test article recieved and re-published to exchange with routing key rss.article.new. Unique check should be False", extra={
+                logger.debug("Test article recieved and re-published to exchange with routing key rss.article.new", extra={
                     "test_article_unique_check":test_article_in_db
                 })
             except Exception as e: 

--- a/src/snowflake/snowflake_python/snowflake.py
+++ b/src/snowflake/snowflake_python/snowflake.py
@@ -121,7 +121,12 @@ def consume_messages():
 
     try:
         connection = pika.BlockingConnection(
-            pika.ConnectionParameters(host=os.environ.get("BROKER_URL", "localhost")))
+            pika.ConnectionParameters(
+                host=os.environ.get("BROKER_URL", "localhost"),
+                heartbeat=600,
+                blocked_connection_timeout=300
+            )
+        )
 
         channel = connection.channel()
 
@@ -134,6 +139,9 @@ def consume_messages():
     
         channel.basic_consume(queue=queue_name, on_message_callback=callback, auto_ack=True)
         channel.start_consuming()
+    
+    except pika.exceptions.StreamLostError as e:
+        pass
 
     except Exception as e:
         logger.exception(f"Error in establishing a connection with the RabbitMQ Broker: {str(e)}", extra={
@@ -160,3 +168,18 @@ if __name__ == "__main__":
 
     logger.info("Snowflake database connection I/O Thread started")
     uvicorn.run(app, host='0.0.0.0', port=8000)
+
+
+"""
+--- Logging error ---
+Traceback (most recent call last):
+  File "/opt/venv/lib/python3.11/site-packages/python_logging_rabbitmq/handlers.py", line 165, in emit
+    self.channel.basic_publish(
+  File "/opt/venv/lib/python3.11/site-packages/pika/adapters/blocking_connection.py", line 2265, in basic_publish
+    self._flush_output()
+  File "/opt/venv/lib/python3.11/site-packages/pika/adapters/blocking_connection.py", line 1353, in _flush_output
+    self._connection._flush_output(lambda: self.is_closed, *waiters)
+  File "/opt/venv/lib/python3.11/site-packages/pika/adapters/blocking_connection.py", line 523, in _flush_output
+    raise self._closed_result.value.error
+pika.exceptions.StreamLostError: Transport indicated EOF
+"""

--- a/src/static_file_ingestor/static_file_ingestor_python/static_file_ingestor.py
+++ b/src/static_file_ingestor/static_file_ingestor_python/static_file_ingestor.py
@@ -297,7 +297,11 @@ def consume_message():
     
     try:
         connection = pika.BlockingConnection(
-            pika.ConnectionParameters(os.environ.get("BROKER_URL", 'localhost'))
+            pika.ConnectionParameters(
+                os.environ.get("BROKER_URL", 'localhost'),
+                heartbeat=600,
+                blocked_connection_timeout=300
+            )
         )
 
         channel = connection.channel()


### PR DESCRIPTION
Added a heartbeat and a block connection timeout for all of the pika connections for each of the RabbitMQ broker connections to try to address the stacking errors that are causing all of the microservices shut down after a while:

```
--- Logging error ---
Traceback (most recent call last):
  File "/opt/venv/lib/python3.11/site-packages/python_logging_rabbitmq/handlers.py", line 165, in emit
    self.channel.basic_publish(
  File "/opt/venv/lib/python3.11/site-packages/pika/adapters/blocking_connection.py", line 2265, in basic_publish
    self._flush_output()
  File "/opt/venv/lib/python3.11/site-packages/pika/adapters/blocking_connection.py", line 1353, in _flush_output
    self._connection._flush_output(lambda: self.is_closed, *waiters)
  File "/opt/venv/lib/python3.11/site-packages/pika/adapters/blocking_connection.py", line 523, in _flush_output
    raise self._closed_result.value.error
pika.exceptions.StreamLostError: Transport indicated EOF
```